### PR TITLE
[Doppins] Upgrade dependency node-linkedin to ^0.5.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "mongoose": "^3.8.16",
     "morgan": "^1.3.1",
     "node-foursquare": "^0.2.1",
-    "node-linkedin": "^0.5.4",
+    "node-linkedin": "^0.5.6",
     "nodemailer": "^1.2.2",
     "passport": "^0.2.1",
     "passport-facebook": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "mongoose": "^3.8.16",
     "morgan": "^1.3.1",
     "node-foursquare": "^0.2.1",
-    "node-linkedin": "^0.3.3",
+    "node-linkedin": "^0.5.4",
     "nodemailer": "^1.2.2",
     "passport": "^0.2.1",
     "passport-facebook": "^1.0.3",


### PR DESCRIPTION
Hi!

A new version was just released of `node-linkedin`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded node-linkedin from `^0.3.3` to `^0.5.4`
